### PR TITLE
Opened route to the home page from the launch page with fade transition.

### DIFF
--- a/lib/pages/launch_page.dart
+++ b/lib/pages/launch_page.dart
@@ -1,6 +1,7 @@
 import 'package:animated_text_kit/animated_text_kit.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:percent_indicator/circular_percent_indicator.dart';
 import 'package:portfolio_website/providers/launch_page_animation_provider.dart';
 import 'package:provider/provider.dart';
@@ -80,7 +81,7 @@ class LaunchPage extends StatelessWidget {
                                     AutoSizeText('I do ',
                                         style: TextStyle(fontSize: width / 39.5, fontFamily: 'Quicksand'),minFontSize: 20,),
                                     AnimatedTextKit(
-                                      //onFinished: () => context.go('/home'),
+                                      onFinished: () => context.go('/home'),
                                       repeatForever: false,
                                       isRepeatingAnimation: false,
                                       animatedTexts: [


### PR DESCRIPTION
This PR serves as  representative of the completion of the launch page, since the launch page was accidentally committed to the master branch 

The launch pages has:

- Percent indicator.
- Animated typed ellipsis after my name.
- My roles are cycled by a rotated animated text.
- The percent indicator is linked to the rotated text, and as the rotation animation is completed, it reaches 100% .

Here is a still preview

![Screenshot from 2023-06-24 14-23-03](https://github.com/Nailsonseat/Portfolio_Website/assets/67797628/92044239-3f3f-493a-9a5a-c81e878df5dc)
